### PR TITLE
update macos M1 M2 M3 to mac series

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -390,7 +390,7 @@
                                 <div class="col-sm-6 col-md-4 col-xl-auto">
                                     <div class="download-box"><img src="img/icon_mac.svg" class="download-icon"><img src="img/icon_apple_silicon.svg" class="download-icon small" alt="Wasabi Wallet M1 M2">
                                         <div class="my-4">
-                                            <div class="system-text">MACOS 12.0+ M1, M2</div>
+                                            <div class="system-text">MACOS 12.0+ M SERIES</div>
                                         </div>
                                         <a href="https://github.com/WalletWasabi/WalletWasabi/releases/download/v2.0.8.1/Wasabi-2.0.8.1-arm64.dmg" target="_blank" class="btn btn-primary w-100">Download</a>
                                         <div class="small-text mt-4">


### PR DESCRIPTION
Apple M3 hardware is available since recently, should also be supported (didn't verify myself) 
Instead of adding `M3`, I think it's better to just rename it to _M SERIES_

suggestions welcome

![image](https://github.com/WalletWasabi/WasabiWalletWebSite/assets/93143998/f75659c2-db3d-4786-bf13-ef4c4efc2419)
