### PR TITLE
Use default name for NIP05

### DIFF
--- a/wwwroot/.well-known/nostr.json
+++ b/wwwroot/.well-known/nostr.json
@@ -1,5 +1,5 @@
 {
     "names": {
-      "nostr": "93bd0c6f3ccbae47388b01ac6ce0b2c013114dca4c08d6e2712d4ff71405a3c3"
+      "_": "93bd0c6f3ccbae47388b01ac6ce0b2c013114dca4c08d6e2712d4ff71405a3c3"
     }
   }


### PR DESCRIPTION
I realized that it was better to use the default name for NIP-05
Next time I'll read to the end of the specs