### PR TITLE
small writing fix

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -98,7 +98,7 @@
             </h6>
             <p class="hiddenText hiddenText-fullwidth">Completely free to use, with transparent code available on <a href="https://github.com/WalletWasabi/WalletWasabi"> GitHub.</a> Contribute by opening a <a
                 href="https://github.com/orgs/WalletWasabi/discussions">Discussion,</a> an
-              <a href="https://github.com/WalletWasabi/WalletWasabi/issues">Issue</a> , or joining our <a href="https://join.slack.com/t/tumblebit/shared_invite/enQtNjQ1MTQ2NzQ1ODI0LWIzOTg5YTM3YmNkOTg1NjZmZTQ3NmM1OTAzYmQyYzk1M2M0MTdlZDk2OTQwNzFiNTg1ZmExNzM0NjgzY2M0Yzg">Slack.</a>
+              <a href="https://github.com/WalletWasabi/WalletWasabi/issues">Issue</a> , or joining our <a href="https://join.slack.com/t/tumblebit/shared_invite/enQtNjQ1MTQ2NzQ1ODI0LWIzOTg5YTM3YmNkOTg1NjZmZTQ3NmM1OTAzYmQyYzk1M2M0MTdlZDk2OTQwNzFiNTg1ZmExNzM0NjgzY2M0Yzg">Slack</a>.
             </p>
           </div>
         </label>
@@ -342,7 +342,7 @@
               <span>Integration</span>
             </h6>
             <p class="hiddenText hiddenText-fullwidth">Wasabi supports <a href="https://github.com/bitcoin-core/HWI">HWI</a> , enabling seamless integration with popular hardware wallets like Trezor,
-              ColdCard, Ledger, Blockstream Jade, and BitBox02. Check the full list of supported devices <a href="https://github.com/WalletWasabi/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-hardware-wallets">here</a>
+              ColdCard, Ledger, Blockstream Jade, and BitBox02. Check the full list of supported devices <a href="https://github.com/WalletWasabi/WalletWasabi/blob/master/WalletWasabi.Documentation/WasabiCompatibility.md#officially-supported-hardware-wallets">here</a>.
             </p>
           </div>
         </label>


### PR DESCRIPTION
move the `.` outside of the hyperlink and add a missing `.`

<img width="337" height="113" alt="image" src="https://github.com/user-attachments/assets/b75ced7f-0ba1-432e-afc0-1b3d2c144b4b" />

<img width="355" height="301" alt="image" src="https://github.com/user-attachments/assets/138dd2b9-ae8c-41a0-8a07-b160bee2c17f" />
